### PR TITLE
Split license and branding license files

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,11 +1,3 @@
-Although the code for this Magentacloud custom web theme for Nextcloud is free and available under the GPL 3
-license below, Deutsche Telekom (including T-Systems) fully reserves all rights to the Telekom brand. To prevent users from getting confused about
-the source of a digital product or experience, there are stringent restrictions on using the Telekom brand and design,
-even when built into code that we provide. For any customization other than explicitly for Telekom or T-Systems, you must
-replace the Deutsche Telekom and T-Systems brand elements contained in the provided sources.
-
-
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/COPYING.DTAG
+++ b/COPYING.DTAG
@@ -1,0 +1,9 @@
+Although the code for the MagentaCLOUD email templates app for Nextcloud is free and available under the AGPL3 
+license, Deutsche Telekom (including T-Systems) fully reserves all rights to the Telekom brand. To prevent users
+from getting confused about the source of a digital product or experience, there are stringent restrictions on using
+the Telekom brand and design, even when built into code that we provide. For any customization other than explicitly
+for Telekom or T-Systems, you must replace the Deutsche Telekom and T-Systems brand elements contained in the provided
+default theme.
+
+Note that especially the theme, the graphical elements, fonts and even the color scheme are intended to implement the
+Telekom brand design, so most files have relationship to brand and need careful check before reuse in own code.


### PR DESCRIPTION
The split of the license files has the following advantages:
1. On modification of standard upstream license, it is easy to simply copy over the template
2. It is visible that there are extra terms to consider for Deutsche Telekom